### PR TITLE
Fix main in package.json to avoid importing errors after npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "es6-tracking-helper",
   "version": "0.1.0",
   "description": "ES6 tracking helper",
-  "main": "src/index.js",
+  "main": "src/TrackingHelper.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Need this for

import TrackingHelper from 'es6-tracking-helper';

after npm install